### PR TITLE
SBPH Bug Fix

### DIFF
--- a/BuildIndex.py
+++ b/BuildIndex.py
@@ -16,7 +16,7 @@ EXISTING_TICKERS = {
     "ENTA": "ENTA - Enanta Pharmaceuticals, Inc.",
     "HEPA": "HEPA - Hepion Pharmaceuticals, Inc.",
     "NTLA": "NTLA - Intellia Therapeutics, Inc.",
-    "SBPH": "SBPH - Spring Bank Pharmaceuticals, Inc.",
+    # "SBPH": "SBPH - Spring Bank Pharmaceuticals, Inc.",
     "VIR": "VIR - Vir Biotechnology, Inc.",
 }
 

--- a/BuildIndex.py
+++ b/BuildIndex.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone, timedelta
 import datetime as dt
 import traceback
 
-DEBUG_MODE = False
+DEBUG_MODE = True
 EXISTING_TICKERS = {
     "HBRI": "HBRI - Hepatitis B Research Index",
     "ALT": "ALT - Altimmune, Inc.",
@@ -188,7 +188,9 @@ def generate_html(tickers_json, css_file):
         name = symbol_data['name']
         price, change_from_open_percent = symbol_data["price"], symbol_data["change_from_open_percent"]
 
-        if change_from_open_percent < 0:
+        if change_from_open_percent is None:
+            continue
+        elif change_from_open_percent < 0:
             # Negative change
             direction = down_facing_triangle
             change_color = "red"
@@ -226,6 +228,10 @@ def update_index_data(current_data, idx_symbol):
         if symbol != idx_symbol:
             cur_mkt_cap = current_data[symbol]['market_cap']
             change_pct = current_data[symbol]['change_from_open_percent']
+            print("SYM: {} | cur_mkt_cap: {} | change_pct: {}".format(symbol, cur_mkt_cap, change_pct))
+            if cur_mkt_cap is None or change_pct is None:
+                log("Skipping")
+                continue
             op_mkt_cap = cur_mkt_cap - (change_pct * cur_mkt_cap)
 
             open_mkt_cap += op_mkt_cap
@@ -368,7 +374,7 @@ def main():
         f.close()
 
         ##### Uncomment for Heroku #####
-        upload()
+        # upload()
 
         # Sleep for 20 minutes, then repeat
         time.sleep(20 * 60)

--- a/BuildIndex.py
+++ b/BuildIndex.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone, timedelta
 import datetime as dt
 import traceback
 
-DEBUG_MODE = True
+DEBUG_MODE = False
 EXISTING_TICKERS = {
     "HBRI": "HBRI - Hepatitis B Research Index",
     "ALT": "ALT - Altimmune, Inc.",
@@ -16,7 +16,7 @@ EXISTING_TICKERS = {
     "ENTA": "ENTA - Enanta Pharmaceuticals, Inc.",
     "HEPA": "HEPA - Hepion Pharmaceuticals, Inc.",
     "NTLA": "NTLA - Intellia Therapeutics, Inc.",
-    # "SBPH": "SBPH - Spring Bank Pharmaceuticals, Inc.",
+    "SBPH": "SBPH - Spring Bank Pharmaceuticals, Inc.",
     "VIR": "VIR - Vir Biotechnology, Inc.",
 }
 
@@ -310,8 +310,12 @@ def upload():
     session.quit()
 
 def main():
+    global DEBUG_MODE
+    if "debug" in sys.argv:
+        DEBUG_MODE = True
+
     # File naming variables
-    filename_prefix = "data" if len(sys.argv) == 1 else sys.argv[1]
+    filename_prefix = "data" if len(sys.argv) == 1 or 'debug' in sys.argv else sys.argv[1]
     log("Beginning run using '{}' prefix".format(filename_prefix))
     storage_file = "{}.json".format(filename_prefix)
     css_file = "{}.css".format(filename_prefix)
@@ -374,7 +378,8 @@ def main():
         f.close()
 
         ##### Uncomment for Heroku #####
-        # upload()
+        if not DEBUG_MODE:
+            upload()
 
         # Sleep for 20 minutes, then repeat
         time.sleep(20 * 60)

--- a/data.html
+++ b/data.html
@@ -2,80 +2,74 @@
         <div class="ticker-wrap">
             <div class="ticker"><div class="ticker__item">
             <span class="tickerSymbol">HBRI - Hepatitis B Research Index</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $566.40</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-2.577%</span>&nbsp;
+		            <span class="tickerValue"> $936.23</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-1.302%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ABUS - Arbutus Biopharma Corporation</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $4.45</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">6.380%</span>&nbsp;
-		            <span class="tickerDirection green">&#x25b2</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">ALT - Altimmune, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $26.70</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.690%</span>&nbsp;
+		            <span class="tickerValue"> $4.33</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-1.140%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
+            <span class="tickerSymbol">ALT - Altimmune, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $22.22</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">0.630%</span>&nbsp;
+		            <span class="tickerDirection green">&#x25b2</span>
+		
+            </div><div class="ticker__item">
             <span class="tickerSymbol">ARWR - Arrowhead Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $40.46</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-7.120%</span>&nbsp;
+		            <span class="tickerValue"> $88.20</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.160%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ASMB - Assembly Biosciences, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $22.16</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.070%</span>&nbsp;
+		            <span class="tickerValue"> $6.29</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-1.260%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">BBI - Brickell Biotech, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $0.91</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.290%</span>&nbsp;
+		            <span class="tickerValue"> $1.61</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.620%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">DRNA - Dicerna Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $20.05</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-7.970%</span>&nbsp;
+		            <span class="tickerValue"> $26.01</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.690%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">DVAX - Dynavax Technologies Corporation</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $8.80</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-2.100%</span>&nbsp;
-		            <span class="tickerDirection red">&#x25bc</span>
+		            <span class="tickerValue"> $9.74</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">2.200%</span>&nbsp;
+		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ENTA - Enanta Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $46.33</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">0.560%</span>&nbsp;
-		            <span class="tickerDirection green">&#x25b2</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">HEPA - Hepion Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $4.44</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-3.270%</span>&nbsp;
+		            <span class="tickerValue"> $51.32</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-4.660%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
-            <span class="tickerSymbol">NTLA - Intellia Therapeutics, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $20.31</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">3.360%</span>&nbsp;
+            <span class="tickerSymbol">HEPA - Hepion Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $2.97</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">4.580%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
-            <span class="tickerSymbol">SBPH - Spring Bank Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $1.49</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-5.100%</span>&nbsp;
+            <span class="tickerSymbol">NTLA - Intellia Therapeutics, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $68.28</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.930%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">VIR - Vir Biotechnology, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $50.19</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.910%</span>&nbsp;
+		            <span class="tickerValue"> $69.71</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-3.140%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div>	</div>

--- a/data.json
+++ b/data.json
@@ -9,7 +9,7 @@
   },
   "ABUS": {
     "price": 4.33,
-    "refresh_time": "2021-02-15 14:17:29",
+    "refresh_time": "2021-02-15 14:31:42",
     "market_cap": 367657000.0,
     "name": "ABUS - Arbutus Biopharma Corporation",
     "change_from_open": -0.05,
@@ -17,7 +17,7 @@
   },
   "ALT": {
     "price": 22.22,
-    "refresh_time": "2021-02-15 14:17:30",
+    "refresh_time": "2021-02-15 14:31:42",
     "market_cap": 825315000.0,
     "name": "ALT - Altimmune, Inc.",
     "change_from_open": 0.14,
@@ -25,7 +25,7 @@
   },
   "ARWR": {
     "price": 88.2,
-    "refresh_time": "2021-02-15 14:17:30",
+    "refresh_time": "2021-02-15 14:31:43",
     "market_cap": 9154000000.0,
     "name": "ARWR - Arrowhead Pharmaceuticals, Inc.",
     "change_from_open": -0.14,
@@ -33,7 +33,7 @@
   },
   "ASMB": {
     "price": 6.29,
-    "refresh_time": "2021-02-15 14:17:31",
+    "refresh_time": "2021-02-15 14:31:43",
     "market_cap": 207710000.0,
     "name": "ASMB - Assembly Biosciences, Inc.",
     "change_from_open": -0.08,
@@ -41,7 +41,7 @@
   },
   "BBI": {
     "price": 1.61,
-    "refresh_time": "2021-02-15 14:17:31",
+    "refresh_time": "2021-02-15 14:31:43",
     "market_cap": 86160000.0,
     "name": "BBI - Brickell Biotech, Inc.",
     "change_from_open": -0.01,
@@ -49,7 +49,7 @@
   },
   "DRNA": {
     "price": 26.01,
-    "refresh_time": "2021-02-15 14:17:31",
+    "refresh_time": "2021-02-15 14:31:44",
     "market_cap": 1952000000.0,
     "name": "DRNA - Dicerna Pharmaceuticals, Inc.",
     "change_from_open": -0.18,
@@ -57,7 +57,7 @@
   },
   "DVAX": {
     "price": 9.74,
-    "refresh_time": "2021-02-15 14:17:32",
+    "refresh_time": "2021-02-15 14:31:44",
     "market_cap": 1073000000.0,
     "name": "DVAX - Dynavax Technologies Corporation",
     "change_from_open": 0.21,
@@ -65,7 +65,7 @@
   },
   "ENTA": {
     "price": 51.32,
-    "refresh_time": "2021-02-15 14:17:32",
+    "refresh_time": "2021-02-15 14:31:45",
     "market_cap": 1034999999.9999999,
     "name": "ENTA - Enanta Pharmaceuticals, Inc.",
     "change_from_open": -2.51,
@@ -73,7 +73,7 @@
   },
   "HEPA": {
     "price": 2.97,
-    "refresh_time": "2021-02-15 14:17:32",
+    "refresh_time": "2021-02-15 14:31:45",
     "market_cap": 95115000.0,
     "name": "HEPA - Hepion Pharmaceuticals, Inc.",
     "change_from_open": 0.13,
@@ -81,7 +81,7 @@
   },
   "NTLA": {
     "price": 68.28,
-    "refresh_time": "2021-02-15 14:17:33",
+    "refresh_time": "2021-02-15 14:31:45",
     "market_cap": 4411000000.0,
     "name": "NTLA - Intellia Therapeutics, Inc.",
     "change_from_open": -0.64,
@@ -89,7 +89,7 @@
   },
   "SBPH": {
     "price": null,
-    "refresh_time": "2021-02-15 14:17:33",
+    "refresh_time": "2021-02-15 14:31:46",
     "market_cap": null,
     "name": "SBPH - Spring Bank Pharmaceuticals, Inc.",
     "change_from_open": null,
@@ -97,7 +97,7 @@
   },
   "VIR": {
     "price": 69.71,
-    "refresh_time": "2021-02-15 14:17:34",
+    "refresh_time": "2021-02-15 14:31:46",
     "market_cap": 8880000000.0,
     "name": "VIR - Vir Biotechnology, Inc.",
     "change_from_open": -2.26,

--- a/data.json
+++ b/data.json
@@ -1,0 +1,106 @@
+{
+  "HBRI": {
+    "price": 936.2319,
+    "open": 28457338376.3,
+    "change_from_open": -370381376.29999924,
+    "change_from_open_percent": -0.013015320385987409,
+    "market_cap": 28086957000.0,
+    "name": "HBRI - Hepatitis B Research Index"
+  },
+  "ABUS": {
+    "price": 4.33,
+    "refresh_time": "2021-02-15 14:17:29",
+    "market_cap": 367657000.0,
+    "name": "ABUS - Arbutus Biopharma Corporation",
+    "change_from_open": -0.05,
+    "change_from_open_percent": -0.011399999999999999
+  },
+  "ALT": {
+    "price": 22.22,
+    "refresh_time": "2021-02-15 14:17:30",
+    "market_cap": 825315000.0,
+    "name": "ALT - Altimmune, Inc.",
+    "change_from_open": 0.14,
+    "change_from_open_percent": 0.0063
+  },
+  "ARWR": {
+    "price": 88.2,
+    "refresh_time": "2021-02-15 14:17:30",
+    "market_cap": 9154000000.0,
+    "name": "ARWR - Arrowhead Pharmaceuticals, Inc.",
+    "change_from_open": -0.14,
+    "change_from_open_percent": -0.0016
+  },
+  "ASMB": {
+    "price": 6.29,
+    "refresh_time": "2021-02-15 14:17:31",
+    "market_cap": 207710000.0,
+    "name": "ASMB - Assembly Biosciences, Inc.",
+    "change_from_open": -0.08,
+    "change_from_open_percent": -0.0126
+  },
+  "BBI": {
+    "price": 1.61,
+    "refresh_time": "2021-02-15 14:17:31",
+    "market_cap": 86160000.0,
+    "name": "BBI - Brickell Biotech, Inc.",
+    "change_from_open": -0.01,
+    "change_from_open_percent": -0.0062
+  },
+  "DRNA": {
+    "price": 26.01,
+    "refresh_time": "2021-02-15 14:17:31",
+    "market_cap": 1952000000.0,
+    "name": "DRNA - Dicerna Pharmaceuticals, Inc.",
+    "change_from_open": -0.18,
+    "change_from_open_percent": -0.0069
+  },
+  "DVAX": {
+    "price": 9.74,
+    "refresh_time": "2021-02-15 14:17:32",
+    "market_cap": 1073000000.0,
+    "name": "DVAX - Dynavax Technologies Corporation",
+    "change_from_open": 0.21,
+    "change_from_open_percent": 0.022000000000000002
+  },
+  "ENTA": {
+    "price": 51.32,
+    "refresh_time": "2021-02-15 14:17:32",
+    "market_cap": 1034999999.9999999,
+    "name": "ENTA - Enanta Pharmaceuticals, Inc.",
+    "change_from_open": -2.51,
+    "change_from_open_percent": -0.0466
+  },
+  "HEPA": {
+    "price": 2.97,
+    "refresh_time": "2021-02-15 14:17:32",
+    "market_cap": 95115000.0,
+    "name": "HEPA - Hepion Pharmaceuticals, Inc.",
+    "change_from_open": 0.13,
+    "change_from_open_percent": 0.0458
+  },
+  "NTLA": {
+    "price": 68.28,
+    "refresh_time": "2021-02-15 14:17:33",
+    "market_cap": 4411000000.0,
+    "name": "NTLA - Intellia Therapeutics, Inc.",
+    "change_from_open": -0.64,
+    "change_from_open_percent": -0.009300000000000001
+  },
+  "SBPH": {
+    "price": null,
+    "refresh_time": "2021-02-15 14:17:33",
+    "market_cap": null,
+    "name": "SBPH - Spring Bank Pharmaceuticals, Inc.",
+    "change_from_open": null,
+    "change_from_open_percent": null
+  },
+  "VIR": {
+    "price": 69.71,
+    "refresh_time": "2021-02-15 14:17:34",
+    "market_cap": 8880000000.0,
+    "name": "VIR - Vir Biotechnology, Inc.",
+    "change_from_open": -2.26,
+    "change_from_open_percent": -0.031400000000000004
+  }
+}


### PR DESCRIPTION
Fixes a bug where symbols that were no longer listed (SBPH) returned `None`, resulting in divide by zero / divide by None error.

Going forward, should ignore any symbol that it can't get a value for.