### PR TITLE
Bs4 regex switch

### DIFF
--- a/BuildIndex.py
+++ b/BuildIndex.py
@@ -110,7 +110,7 @@ def get_all_text_on_page(symbol):
     """ Retrieve all non-HTML content on page
     """
     req = requests.get(f"https://finance.yahoo.com/quote/{symbol}")
-    soup = BeautifulSoup(req.content)
+    soup = BeautifulSoup(req.content, features="html.parser")
     return soup.get_text().strip()
 
 
@@ -290,7 +290,7 @@ def log(msg, err=None):
     to_write = '{} > {}\n'.format(time, msg)
     if err is not None:
         to_write += '{}\n'.format(err)
-        to_write += '{}\n'.format(traceback.print_exc())
+        if DEBUG_MODE: to_write += '{}\n'.format(traceback.print_exc())
     if DEBUG_MODE:
         print(to_write)
     f = open('./log.txt', 'a+')

--- a/BuildIndex.py
+++ b/BuildIndex.py
@@ -1,7 +1,14 @@
-import requests, json, time, os, sys, ftplib
-from datetime import date, datetime, timezone, timedelta
+import requests
+import json
+import time
+import os
+import sys
+import ftplib
+from datetime import datetime, timezone, timedelta
 import datetime as dt
 import traceback
+import re
+from bs4 import BeautifulSoup
 
 DEBUG_MODE = False
 EXISTING_TICKERS = {
@@ -16,7 +23,6 @@ EXISTING_TICKERS = {
     "ENTA": "ENTA - Enanta Pharmaceuticals, Inc.",
     "HEPA": "HEPA - Hepion Pharmaceuticals, Inc.",
     "NTLA": "NTLA - Intellia Therapeutics, Inc.",
-    "SBPH": "SBPH - Spring Bank Pharmaceuticals, Inc.",
     "VIR": "VIR - Vir Biotechnology, Inc.",
 }
 
@@ -31,27 +37,20 @@ def build_index_data(symbol, current_data):
     try:
         action = "HTML content"
         if DEBUG_MODE: log("Retrieving {} for {}".format(action, symbol))
-        content = get_html_content(symbol)
+        content = get_all_text_on_page(symbol)
     except Exception as e:
         print(e)
         log("Error retrieving {} data for: {}".format(action, symbol), e)
 
-    # Retrieve the change in percentage, value
+    # Retrieve the change in percentage, value, and current price
     try:
         action = "change amounts"
         if DEBUG_MODE: log("Retrieving {} for {}".format(action, symbol))
-        change_amt, change_pct = scrape_yahoo_change(content)
+        price_data = scrape_price_and_change(content)
+        price = price_data[0]
+        change_amt = price_data[1]
+        change_pct = price_data[2] / 100
         log("[{}] Retrieved change amount: {}\tchange percent: {}".format(symbol, change_amt, change_pct))
-    except Exception as e:
-        print(e)
-        log("Error retrieving {} data for: {}".format(action, symbol), e)
-
-    # Retrieve the Price amount
-    try:
-        action = "price"
-        if DEBUG_MODE: log("Retrieving {} for {}".format(action, symbol))
-        price = scrape_yahoo_price(content)
-        log("[{}] Retrieved price: {}".format(symbol, price))
     except Exception as e:
         print(e)
         log("Error retrieving {} data for: {}".format(action, symbol), e)
@@ -107,28 +106,27 @@ def search_and_discard(str_to_find, str_to_search, keep_all_before=False, additi
     return str_to_search[i + additional_spaces:]
 
 
-def scrape_yahoo_change(content):
-    """ This function will scrape the Yahoo finance page and return a tuple of
-    (change amount, change percentage)
+def get_all_text_on_page(symbol):
+    """ Retrieve all non-HTML content on page
     """
-    content = search_and_discard('quote-header-info', content)
-    content = search_and_discard('data-reactid="51"', content, additional_spaces=len('data-reactid="51"') + 1)
-    content = search_and_discard('<', content, keep_all_before=True)
-
-    split_str = content.split(' ')
-    split_str[1] = split_str[1].replace('(', '')
-    split_str[1] = split_str[1].replace(')', '')
-    return float(split_str[0]), float(split_str[1][:-1]) / 100
+    req = requests.get(f"https://finance.yahoo.com/quote/{symbol}")
+    soup = BeautifulSoup(req.content)
+    return soup.get_text().strip()
 
 
-def scrape_yahoo_price(content):
-    """ This function will scrape the yahoo finance page for the price
+def scrape_price_and_change(content):
+    """ Retrieve the price information and return a list of:
+        [ price, valueChange, valueChangePercent ]
     """
+    text = search_and_discard(')As of ', content, keep_all_before=True, additional_spaces=1)
+    text = search_and_discard('Visitors trend', text, additional_spaces=1)
+    data = re.findall('\d+\.\d{2,5}[-|+]\d+\.\d{2,5}\W+\d+\.\d{2,5}%\W{1}', text)
+    data = re.findall('\W{0,1}\d+\.\d+', data[0])
 
-    content = search_and_discard('quote-header-info', content)
-    content = search_and_discard('data-reactid="50"', content, additional_spaces=len('data-reactid="50"')+1)
-    content = search_and_discard('<', content, keep_all_before=True)
-    return float(content)
+    # Cast all data to float, then return
+    for i in range(len(data)):
+        data[i] = float(data[i])
+    return data
 
 
 def scrape_yahoo_mkt_cap(content):
@@ -142,14 +140,10 @@ def scrape_yahoo_mkt_cap(content):
         'K': 1000,
     }
 
-    to_find = '<div id="Main" role="content"'
-    content = search_and_discard(to_find, content)
-    content = search_and_discard('Market Cap', content)
-    content = search_and_discard('<span', content)
-    content = search_and_discard('>', content, additional_spaces=1)
-    content = search_and_discard('<', content, keep_all_before=True)
-    mkt_cap = float(content.strip()[:-1])
-    mkt_cap_multiplier = content.strip()[-1]
+    data = re.findall('Market Cap\d+\.*\d*[M|B|K]{1}', content)
+    data = re.findall('\d+\.*\d*[M|B|K]{1}', data[0])
+    mkt_cap = float(data[0].strip()[:-1])
+    mkt_cap_multiplier = data[0].strip()[-1]
     return mkt_cap * multipliers[mkt_cap_multiplier]
 
 
@@ -159,11 +153,7 @@ def scrape_yahoo_name(symbol, content):
     """
     name = symbol
     if name not in EXISTING_TICKERS.keys():
-        content = search_and_discard('quote-header-info', content)
-        content = search_and_discard('<h1', content)
-        content = search_and_discard('>', content, additional_spaces=1)
-        content = search_and_discard('<', content, keep_all_before=True).strip()
-        name = content
+        name = search_and_discard('Stock Price,', content, keep_all_before=True)
     else:
         name = EXISTING_TICKERS[symbol]
     return name
@@ -383,6 +373,7 @@ def main():
 
         # Sleep for 20 minutes, then repeat
         time.sleep(20 * 60)
+
 
 if __name__ == "__main__":
     main()

--- a/data.html
+++ b/data.html
@@ -2,74 +2,74 @@
         <div class="ticker-wrap">
             <div class="ticker"><div class="ticker__item">
             <span class="tickerSymbol">HBRI - Hepatitis B Research Index</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $936.23</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.302%</span>&nbsp;
-		            <span class="tickerDirection red">&#x25bc</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">ABUS - Arbutus Biopharma Corporation</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $4.33</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.140%</span>&nbsp;
-		            <span class="tickerDirection red">&#x25bc</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">ALT - Altimmune, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $22.22</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">0.630%</span>&nbsp;
+		            <span class="tickerValue"> $785.62</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">0.003%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
-            <span class="tickerSymbol">ARWR - Arrowhead Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $88.20</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.160%</span>&nbsp;
+            <span class="tickerSymbol">ABUS - Arbutus Biopharma Corporation</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $3.20</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">0.310%</span>&nbsp;
+		            <span class="tickerDirection green">&#x25b2</span>
+		
+            </div><div class="ticker__item">
+            <span class="tickerSymbol">ALT - Altimmune, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $12.57</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.870%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
+            <span class="tickerSymbol">ARWR - Arrowhead Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $71.35</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">0.510%</span>&nbsp;
+		            <span class="tickerDirection green">&#x25b2</span>
+		
+            </div><div class="ticker__item">
             <span class="tickerSymbol">ASMB - Assembly Biosciences, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $6.29</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.260%</span>&nbsp;
+		            <span class="tickerValue"> $4.31</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-1.370%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">BBI - Brickell Biotech, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $1.61</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.620%</span>&nbsp;
-		            <span class="tickerDirection red">&#x25bc</span>
+		            <span class="tickerValue"> $0.92</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">3.910%</span>&nbsp;
+		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">DRNA - Dicerna Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $26.01</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.690%</span>&nbsp;
+		            <span class="tickerValue"> $28.81</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.170%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">DVAX - Dynavax Technologies Corporation</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $9.74</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">2.200%</span>&nbsp;
+		            <span class="tickerValue"> $9.55</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">0.050%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ENTA - Enanta Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $51.32</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-4.660%</span>&nbsp;
+		            <span class="tickerValue"> $51.06</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-2.540%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">HEPA - Hepion Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $2.97</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">4.580%</span>&nbsp;
+		            <span class="tickerValue"> $1.71</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">1.490%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">NTLA - Intellia Therapeutics, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $68.28</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.930%</span>&nbsp;
-		            <span class="tickerDirection red">&#x25bc</span>
+		            <span class="tickerValue"> $76.80</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">2.950%</span>&nbsp;
+		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">VIR - Vir Biotechnology, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $69.71</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-3.140%</span>&nbsp;
+		            <span class="tickerValue"> $48.62</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-2.450%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div>	</div>

--- a/data.html
+++ b/data.html
@@ -2,9 +2,9 @@
         <div class="ticker-wrap">
             <div class="ticker"><div class="ticker__item">
             <span class="tickerSymbol">HBRI - Hepatitis B Research Index</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $785.62</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">0.003%</span>&nbsp;
-		            <span class="tickerDirection green">&#x25b2</span>
+		            <span class="tickerValue"> $784.27</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.163%</span>&nbsp;
+		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ABUS - Arbutus Biopharma Corporation</span>&nbsp;&nbsp;
@@ -14,32 +14,32 @@
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ALT - Altimmune, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $12.57</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.870%</span>&nbsp;
+		            <span class="tickerValue"> $12.58</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.790%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ARWR - Arrowhead Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $71.35</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">0.510%</span>&nbsp;
+		            <span class="tickerValue"> $71.38</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">0.550%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ASMB - Assembly Biosciences, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $4.31</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.370%</span>&nbsp;
+		            <span class="tickerValue"> $4.30</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-1.600%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">BBI - Brickell Biotech, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $0.92</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">3.910%</span>&nbsp;
+		            <span class="tickerValue"> $0.94</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">5.810%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">DRNA - Dicerna Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $28.81</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.170%</span>&nbsp;
+		            <span class="tickerValue"> $28.77</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.310%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
@@ -50,26 +50,26 @@
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ENTA - Enanta Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $51.06</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-2.540%</span>&nbsp;
+		            <span class="tickerValue"> $51.12</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-2.420%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">HEPA - Hepion Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $1.71</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">1.490%</span>&nbsp;
+		            <span class="tickerValue"> $1.70</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">1.190%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">NTLA - Intellia Therapeutics, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $76.80</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">2.950%</span>&nbsp;
+		            <span class="tickerValue"> $76.54</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">2.600%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">VIR - Vir Biotechnology, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $48.62</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-2.450%</span>&nbsp;
+		            <span class="tickerValue"> $48.42</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-2.850%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div>	</div>

--- a/data.html
+++ b/data.html
@@ -2,74 +2,74 @@
         <div class="ticker-wrap">
             <div class="ticker"><div class="ticker__item">
             <span class="tickerSymbol">HBRI - Hepatitis B Research Index</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $784.27</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.163%</span>&nbsp;
+		            <span class="tickerValue"> $784.37</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.144%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">ABUS - Arbutus Biopharma Corporation</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $3.20</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">0.310%</span>&nbsp;
-		            <span class="tickerDirection green">&#x25b2</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">ALT - Altimmune, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $12.58</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-0.790%</span>&nbsp;
-		            <span class="tickerDirection red">&#x25bc</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">ARWR - Arrowhead Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $71.38</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">0.550%</span>&nbsp;
-		            <span class="tickerDirection green">&#x25b2</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">ASMB - Assembly Biosciences, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $4.30</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-1.600%</span>&nbsp;
-		            <span class="tickerDirection red">&#x25bc</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">BBI - Brickell Biotech, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $0.94</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">5.810%</span>&nbsp;
-		            <span class="tickerDirection green">&#x25b2</span>
-		
-            </div><div class="ticker__item">
-            <span class="tickerSymbol">DRNA - Dicerna Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $28.77</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $3.18</span>&nbsp;&nbsp;
 		            <span class="tickerPercent red">-0.310%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
-            <span class="tickerSymbol">DVAX - Dynavax Technologies Corporation</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $9.55</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">0.050%</span>&nbsp;
+            <span class="tickerSymbol">ALT - Altimmune, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $12.50</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-1.420%</span>&nbsp;
+		            <span class="tickerDirection red">&#x25bc</span>
+		
+            </div><div class="ticker__item">
+            <span class="tickerSymbol">ARWR - Arrowhead Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $71.24</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">0.350%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
+            <span class="tickerSymbol">ASMB - Assembly Biosciences, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $4.29</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-1.950%</span>&nbsp;
+		            <span class="tickerDirection red">&#x25bc</span>
+		
+            </div><div class="ticker__item">
+            <span class="tickerSymbol">BBI - Brickell Biotech, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $0.93</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">4.990%</span>&nbsp;
+		            <span class="tickerDirection green">&#x25b2</span>
+		
+            </div><div class="ticker__item">
+            <span class="tickerSymbol">DRNA - Dicerna Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $28.74</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.420%</span>&nbsp;
+		            <span class="tickerDirection red">&#x25bc</span>
+		
+            </div><div class="ticker__item">
+            <span class="tickerSymbol">DVAX - Dynavax Technologies Corporation</span>&nbsp;&nbsp;
+		            <span class="tickerValue"> $9.53</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-0.100%</span>&nbsp;
+		            <span class="tickerDirection red">&#x25bc</span>
+		
+            </div><div class="ticker__item">
             <span class="tickerSymbol">ENTA - Enanta Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $51.12</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-2.420%</span>&nbsp;
+		            <span class="tickerValue"> $51.29</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-2.100%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">HEPA - Hepion Pharmaceuticals, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $1.70</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">1.190%</span>&nbsp;
+		            <span class="tickerValue"> $1.71</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">1.780%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">NTLA - Intellia Therapeutics, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $76.54</span>&nbsp;&nbsp;
-		            <span class="tickerPercent green">2.600%</span>&nbsp;
+		            <span class="tickerValue"> $77.26</span>&nbsp;&nbsp;
+		            <span class="tickerPercent green">3.560%</span>&nbsp;
 		            <span class="tickerDirection green">&#x25b2</span>
 		
             </div><div class="ticker__item">
             <span class="tickerSymbol">VIR - Vir Biotechnology, Inc.</span>&nbsp;&nbsp;
-		            <span class="tickerValue"> $48.42</span>&nbsp;&nbsp;
-		            <span class="tickerPercent red">-2.850%</span>&nbsp;
+		            <span class="tickerValue"> $48.22</span>&nbsp;&nbsp;
+		            <span class="tickerPercent red">-3.250%</span>&nbsp;
 		            <span class="tickerDirection red">&#x25bc</span>
 		
             </div>	</div>

--- a/data.json
+++ b/data.json
@@ -1,106 +1,106 @@
 {
   "HBRI": {
-    "price": 784.2729,
-    "open": 23566527863.5,
-    "change_from_open": -38340863.5,
-    "change_from_open_percent": -0.001626920338968669,
-    "market_cap": 23528187000.0,
+    "price": 784.3678,
+    "open": 23565018472.300003,
+    "change_from_open": -33984472.30000305,
+    "change_from_open_percent": -0.0014421576770648754,
+    "market_cap": 23531034000.0,
     "name": "HBRI - Hepatitis B Research Index"
   },
   "ABUS": {
-    "price": 3.2,
-    "refresh_time": "2021-04-23 11:57:06",
-    "market_cap": 306622000.0,
+    "price": 3.18,
+    "refresh_time": "2021-04-23 12:05:31",
+    "market_cap": 304705000.0,
     "name": "ABUS - Arbutus Biopharma Corporation",
-    "change_from_open": 0.01,
-    "change_from_open_percent": 0.0031
-  },
-  "ALT": {
-    "price": 12.58,
-    "refresh_time": "2021-04-23 11:57:06",
-    "market_cap": 458137000.0,
-    "name": "ALT - Altimmune, Inc.",
-    "change_from_open": -0.1,
-    "change_from_open_percent": -0.0079
-  },
-  "ARWR": {
-    "price": 71.38,
-    "refresh_time": "2021-04-23 11:57:07",
-    "market_cap": 7204000000.0,
-    "name": "ARWR - Arrowhead Pharmaceuticals, Inc.",
-    "change_from_open": 0.39,
-    "change_from_open_percent": 0.0055000000000000005
-  },
-  "ASMB": {
-    "price": 4.3,
-    "refresh_time": "2021-04-23 11:57:07",
-    "market_cap": 172254000.0,
-    "name": "ASMB - Assembly Biosciences, Inc.",
-    "change_from_open": -0.07,
-    "change_from_open_percent": -0.016
-  },
-  "BBI": {
-    "price": 0.9386,
-    "refresh_time": "2021-04-23 11:57:08",
-    "market_cap": 62820000.0,
-    "name": "BBI - Brickell Biotech, Inc.",
-    "change_from_open": 0.0515,
-    "change_from_open_percent": 0.0581
-  },
-  "DRNA": {
-    "price": 28.77,
-    "refresh_time": "2021-04-23 11:57:08",
-    "market_cap": 2204000000.0,
-    "name": "DRNA - Dicerna Pharmaceuticals, Inc.",
-    "change_from_open": -0.09,
+    "change_from_open": -0.01,
     "change_from_open_percent": -0.0031
   },
+  "ALT": {
+    "price": 12.5,
+    "refresh_time": "2021-04-23 12:05:32",
+    "market_cap": 455224000.0,
+    "name": "ALT - Altimmune, Inc.",
+    "change_from_open": -0.18,
+    "change_from_open_percent": -0.014199999999999999
+  },
+  "ARWR": {
+    "price": 71.24,
+    "refresh_time": "2021-04-23 12:05:32",
+    "market_cap": 7190000000.0,
+    "name": "ARWR - Arrowhead Pharmaceuticals, Inc.",
+    "change_from_open": 0.25,
+    "change_from_open_percent": 0.0034999999999999996
+  },
+  "ASMB": {
+    "price": 4.285,
+    "refresh_time": "2021-04-23 12:05:33",
+    "market_cap": 171653000.0,
+    "name": "ASMB - Assembly Biosciences, Inc.",
+    "change_from_open": -0.085,
+    "change_from_open_percent": -0.0195
+  },
+  "BBI": {
+    "price": 0.9314,
+    "refresh_time": "2021-04-23 12:05:33",
+    "market_cap": 62339000.0,
+    "name": "BBI - Brickell Biotech, Inc.",
+    "change_from_open": 0.0443,
+    "change_from_open_percent": 0.0499
+  },
+  "DRNA": {
+    "price": 28.74,
+    "refresh_time": "2021-04-23 12:05:34",
+    "market_cap": 2202000000.0,
+    "name": "DRNA - Dicerna Pharmaceuticals, Inc.",
+    "change_from_open": -0.12,
+    "change_from_open_percent": -0.0042
+  },
   "DVAX": {
-    "price": 9.55,
-    "refresh_time": "2021-04-23 11:57:09",
-    "market_cap": 1076000000.0,
+    "price": 9.53,
+    "refresh_time": "2021-04-23 12:05:34",
+    "market_cap": 1075000000.0,
     "name": "DVAX - Dynavax Technologies Corporation",
-    "change_from_open": 0.01,
-    "change_from_open_percent": 0.0005
+    "change_from_open": -0.01,
+    "change_from_open_percent": -0.001
   },
   "ENTA": {
-    "price": 51.12,
-    "refresh_time": "2021-04-23 11:57:09",
-    "market_cap": 1030999999.9999999,
+    "price": 51.29,
+    "refresh_time": "2021-04-23 12:05:35",
+    "market_cap": 1034999999.9999999,
     "name": "ENTA - Enanta Pharmaceuticals, Inc.",
-    "change_from_open": -1.27,
-    "change_from_open_percent": -0.0242
+    "change_from_open": -1.1,
+    "change_from_open_percent": -0.021
   },
   "HEPA": {
-    "price": 1.7,
-    "refresh_time": "2021-04-23 11:57:10",
-    "market_cap": 130354000.00000001,
+    "price": 1.7099,
+    "refresh_time": "2021-04-23 12:05:35",
+    "market_cap": 131113000.0,
     "name": "HEPA - Hepion Pharmaceuticals, Inc.",
-    "change_from_open": 0.02,
-    "change_from_open_percent": 0.011899999999999999
+    "change_from_open": 0.0299,
+    "change_from_open_percent": 0.0178
   },
   "NTLA": {
-    "price": 76.54,
-    "refresh_time": "2021-04-23 11:57:10",
-    "market_cap": 4838000000.0,
+    "price": 77.26,
+    "refresh_time": "2021-04-23 12:05:36",
+    "market_cap": 4884000000.0,
     "name": "NTLA - Intellia Therapeutics, Inc.",
-    "change_from_open": 1.94,
-    "change_from_open_percent": 0.026000000000000002
+    "change_from_open": 2.66,
+    "change_from_open_percent": 0.0356
   },
   "SBPH": {
     "price": null,
-    "refresh_time": "2021-04-23 11:57:11",
+    "refresh_time": "2021-04-23 12:05:36",
     "market_cap": null,
-    "name": "Symbol Lookup from Yahoo FinanceHomeMailNewsFinanceSportsEntertainmentSearchMobileMore...Yahoo FinanceSearchSign inMailSign in to view your mailFinance HomeWatchlistsMy PortfolioScreenersYahoo Finance PlusMarketsNewsPersonal FinanceVideosIndustriesTechContact UsU.S. markets close in 4 hours 3 minutesS&P 5004,176.04+41.06(+0.99%)Dow 3033,993.56+177.66(+0.53%)Nasdaq14,004.17+185.75(+1.34%)Symbols similar to 'sbph'All (8)Stocks (8)Mutual Funds (0)ETFs (0)Indices (0)Futures (0)Currencies (0)SymbolNameLast PriceIndustry / CategoryTypeExchangeSPHSuburban Propane Partners, L.P.14.65UtilitiesStocksNYQSBHSally Beauty Holdings, Inc. (Na20.44Consumer CyclicalStocksNYQTBPHTheravance Biopharma, Inc.21.26HealthcareStocksNGMLBPHLongboard Pharmaceuticals, Inc.10.94HealthcareStocksNGMSCPHscPharmaceuticals Inc.6.79HealthcareStocksNMSSPPHSPENCER PHARMACEUTICAL INC0.00N/AStocksPNKKBPHKYTO TECHNOLOGY AND LIFE SCI IN1.90Financial ServicesStocksPNKSBPHSBPHN/AN/AStocksNCMAlready got your third stimulus check? A bonus amount may be on the wayMoneyWiseEconomist: Government will 'attempt' to make unearned and earned tax rate similarYahoo Finance VideoThe worst mistake you can make on a Zoom job interview: \u2018It\u2019s the first thing that occurs and it never goes well\u2019Yahoo FinanceAdvertise with us\u00a9 2021 Verizon Media. All rights reserved.Data DisclaimerHelpSuggestionsPrivacy DashboardPrivacy (Updated)About Our AdsTerms (Updated)Sitema",
+    "name": "Symbol Lookup from Yahoo FinanceHomeMailNewsFinanceSportsEntertainmentSearchMobileMore...Yahoo FinanceSearchSign inMailSign in to view your mailFinance HomeWatchlistsMy PortfolioScreenersYahoo Finance PlusMarketsNewsPersonal FinanceVideosIndustriesTechContact UsU.S. markets close in 3 hours 55 minutesS&P 5004,177.10+42.12(+1.02%)Dow 3033,990.98+175.08(+0.52%)Nasdaq14,009.77+191.35(+1.38%)Symbols similar to 'sbph'All (8)Stocks (8)Mutual Funds (0)ETFs (0)Indices (0)Futures (0)Currencies (0)SymbolNameLast PriceIndustry / CategoryTypeExchangeSPHSuburban Propane Partners, L.P.14.63UtilitiesStocksNYQSBHSally Beauty Holdings, Inc. (Na20.41Consumer CyclicalStocksNYQTBPHTheravance Biopharma, Inc.21.18HealthcareStocksNGMLBPHLongboard Pharmaceuticals, Inc.10.94HealthcareStocksNGMSCPHscPharmaceuticals Inc.6.84HealthcareStocksNMSSPPHSPENCER PHARMACEUTICAL INC0.00N/AStocksPNKKBPHKYTO TECHNOLOGY AND LIFE SCI IN1.90Financial ServicesStocksPNKSBPHSBPHN/AN/AStocksNCMAlready got your third stimulus check? A bonus amount may be on the wayMoneyWiseEconomist: Government will 'attempt' to make unearned and earned tax rate similarYahoo Finance VideoThe worst mistake you can make on a Zoom job interview: \u2018It\u2019s the first thing that occurs and it never goes well\u2019Yahoo FinanceAdvertise with us\u00a9 2021 Verizon Media. All rights reserved.Data DisclaimerHelpSuggestionsPrivacy DashboardPrivacy (Updated)About Our AdsTerms (Updated)Sitema",
     "change_from_open": null,
     "change_from_open_percent": null
   },
   "VIR": {
-    "price": 48.42,
-    "refresh_time": "2021-04-23 11:57:11",
-    "market_cap": 6045000000.0,
+    "price": 48.22,
+    "refresh_time": "2021-04-23 12:05:36",
+    "market_cap": 6020000000.0,
     "name": "VIR - Vir Biotechnology, Inc.",
-    "change_from_open": -1.42,
-    "change_from_open_percent": -0.0285
+    "change_from_open": -1.62,
+    "change_from_open_percent": -0.0325
   }
 }

--- a/data.json
+++ b/data.json
@@ -1,106 +1,106 @@
 {
   "HBRI": {
-    "price": 785.6161333333333,
-    "open": 23567664460.6,
-    "change_from_open": 819539.4000015259,
-    "change_from_open_percent": 3.477389120893236e-05,
-    "market_cap": 23568484000.0,
+    "price": 784.2729,
+    "open": 23566527863.5,
+    "change_from_open": -38340863.5,
+    "change_from_open_percent": -0.001626920338968669,
+    "market_cap": 23528187000.0,
     "name": "HBRI - Hepatitis B Research Index"
   },
   "ABUS": {
     "price": 3.2,
-    "refresh_time": "2021-04-23 11:52:27",
+    "refresh_time": "2021-04-23 11:57:06",
     "market_cap": 306622000.0,
     "name": "ABUS - Arbutus Biopharma Corporation",
     "change_from_open": 0.01,
     "change_from_open_percent": 0.0031
   },
   "ALT": {
-    "price": 12.57,
-    "refresh_time": "2021-04-23 11:52:28",
-    "market_cap": 457773000.0,
+    "price": 12.58,
+    "refresh_time": "2021-04-23 11:57:06",
+    "market_cap": 458137000.0,
     "name": "ALT - Altimmune, Inc.",
-    "change_from_open": -0.11,
-    "change_from_open_percent": -0.0087
+    "change_from_open": -0.1,
+    "change_from_open_percent": -0.0079
   },
   "ARWR": {
-    "price": 71.35,
-    "refresh_time": "2021-04-23 11:52:28",
-    "market_cap": 7201000000.0,
+    "price": 71.38,
+    "refresh_time": "2021-04-23 11:57:07",
+    "market_cap": 7204000000.0,
     "name": "ARWR - Arrowhead Pharmaceuticals, Inc.",
-    "change_from_open": 0.36,
-    "change_from_open_percent": 0.0051
+    "change_from_open": 0.39,
+    "change_from_open_percent": 0.0055000000000000005
   },
   "ASMB": {
-    "price": 4.31,
-    "refresh_time": "2021-04-23 11:52:29",
-    "market_cap": 172655000.0,
+    "price": 4.3,
+    "refresh_time": "2021-04-23 11:57:07",
+    "market_cap": 172254000.0,
     "name": "ASMB - Assembly Biosciences, Inc.",
-    "change_from_open": -0.06,
-    "change_from_open_percent": -0.0137
+    "change_from_open": -0.07,
+    "change_from_open_percent": -0.016
   },
   "BBI": {
-    "price": 0.9218,
-    "refresh_time": "2021-04-23 11:52:29",
-    "market_cap": 61696000.0,
+    "price": 0.9386,
+    "refresh_time": "2021-04-23 11:57:08",
+    "market_cap": 62820000.0,
     "name": "BBI - Brickell Biotech, Inc.",
-    "change_from_open": 0.0347,
-    "change_from_open_percent": 0.0391
+    "change_from_open": 0.0515,
+    "change_from_open_percent": 0.0581
   },
   "DRNA": {
-    "price": 28.81,
-    "refresh_time": "2021-04-23 11:52:30",
-    "market_cap": 2207000000.0,
+    "price": 28.77,
+    "refresh_time": "2021-04-23 11:57:08",
+    "market_cap": 2204000000.0,
     "name": "DRNA - Dicerna Pharmaceuticals, Inc.",
-    "change_from_open": -0.05,
-    "change_from_open_percent": -0.0017000000000000001
+    "change_from_open": -0.09,
+    "change_from_open_percent": -0.0031
   },
   "DVAX": {
     "price": 9.55,
-    "refresh_time": "2021-04-23 11:52:30",
+    "refresh_time": "2021-04-23 11:57:09",
     "market_cap": 1076000000.0,
     "name": "DVAX - Dynavax Technologies Corporation",
     "change_from_open": 0.01,
     "change_from_open_percent": 0.0005
   },
   "ENTA": {
-    "price": 51.06,
-    "refresh_time": "2021-04-23 11:52:31",
-    "market_cap": 1030000000.0,
+    "price": 51.12,
+    "refresh_time": "2021-04-23 11:57:09",
+    "market_cap": 1030999999.9999999,
     "name": "ENTA - Enanta Pharmaceuticals, Inc.",
-    "change_from_open": -1.33,
-    "change_from_open_percent": -0.0254
+    "change_from_open": -1.27,
+    "change_from_open_percent": -0.0242
   },
   "HEPA": {
-    "price": 1.705,
-    "refresh_time": "2021-04-23 11:52:31",
-    "market_cap": 130738000.0,
+    "price": 1.7,
+    "refresh_time": "2021-04-23 11:57:10",
+    "market_cap": 130354000.00000001,
     "name": "HEPA - Hepion Pharmaceuticals, Inc.",
-    "change_from_open": 0.025,
-    "change_from_open_percent": 0.0149
+    "change_from_open": 0.02,
+    "change_from_open_percent": 0.011899999999999999
   },
   "NTLA": {
-    "price": 76.8,
-    "refresh_time": "2021-04-23 11:52:31",
-    "market_cap": 4855000000.0,
+    "price": 76.54,
+    "refresh_time": "2021-04-23 11:57:10",
+    "market_cap": 4838000000.0,
     "name": "NTLA - Intellia Therapeutics, Inc.",
-    "change_from_open": 2.2,
-    "change_from_open_percent": 0.029500000000000002
+    "change_from_open": 1.94,
+    "change_from_open_percent": 0.026000000000000002
   },
   "SBPH": {
     "price": null,
-    "refresh_time": "2021-04-23 11:52:32",
+    "refresh_time": "2021-04-23 11:57:11",
     "market_cap": null,
-    "name": "Symbol Lookup from Yahoo FinanceHomeMailNewsFinanceSportsEntertainmentSearchMobileMore...Yahoo FinanceSearchSign inMailSign in to view your mailFinance HomeWatchlistsMy PortfolioScreenersYahoo Finance PlusMarketsNewsPersonal FinanceVideosIndustriesTechContact UsU.S. markets close in 4 hours 8 minutesS&P 5004,175.26+40.28(+0.97%)Dow 3033,980.23+164.33(+0.49%)Nasdaq14,007.35+188.94(+1.37%)Symbols similar to 'sbph'All (8)Stocks (8)Mutual Funds (0)ETFs (0)Indices (0)Futures (0)Currencies (0)SymbolNameLast PriceIndustry / CategoryTypeExchangeSPHSuburban Propane Partners, L.P.14.65UtilitiesStocksNYQSBHSally Beauty Holdings, Inc. (Na20.46Consumer CyclicalStocksNYQTBPHTheravance Biopharma, Inc.21.30HealthcareStocksNGMLBPHLongboard Pharmaceuticals, Inc.10.94HealthcareStocksNGMSCPHscPharmaceuticals Inc.6.83HealthcareStocksNMSSPPHSPENCER PHARMACEUTICAL INC0.00N/AStocksPNKKBPHKYTO TECHNOLOGY AND LIFE SCI IN1.90Financial ServicesStocksPNKSBPHSBPHN/AN/AStocksNCMAlready got your third stimulus check? A bonus amount may be on the wayMoneyWiseEconomist: Government will 'attempt' to make unearned and earned tax rate similarYahoo Finance VideoThe worst mistake you can make on a Zoom job interview: \u2018It\u2019s the first thing that occurs and it never goes well\u2019Yahoo FinanceAdvertise with us\u00a9 2021 Verizon Media. All rights reserved.Data DisclaimerHelpSuggestionsPrivacy DashboardPrivacy (Updated)About Our AdsTerms (Updated)Sitema",
+    "name": "Symbol Lookup from Yahoo FinanceHomeMailNewsFinanceSportsEntertainmentSearchMobileMore...Yahoo FinanceSearchSign inMailSign in to view your mailFinance HomeWatchlistsMy PortfolioScreenersYahoo Finance PlusMarketsNewsPersonal FinanceVideosIndustriesTechContact UsU.S. markets close in 4 hours 3 minutesS&P 5004,176.04+41.06(+0.99%)Dow 3033,993.56+177.66(+0.53%)Nasdaq14,004.17+185.75(+1.34%)Symbols similar to 'sbph'All (8)Stocks (8)Mutual Funds (0)ETFs (0)Indices (0)Futures (0)Currencies (0)SymbolNameLast PriceIndustry / CategoryTypeExchangeSPHSuburban Propane Partners, L.P.14.65UtilitiesStocksNYQSBHSally Beauty Holdings, Inc. (Na20.44Consumer CyclicalStocksNYQTBPHTheravance Biopharma, Inc.21.26HealthcareStocksNGMLBPHLongboard Pharmaceuticals, Inc.10.94HealthcareStocksNGMSCPHscPharmaceuticals Inc.6.79HealthcareStocksNMSSPPHSPENCER PHARMACEUTICAL INC0.00N/AStocksPNKKBPHKYTO TECHNOLOGY AND LIFE SCI IN1.90Financial ServicesStocksPNKSBPHSBPHN/AN/AStocksNCMAlready got your third stimulus check? A bonus amount may be on the wayMoneyWiseEconomist: Government will 'attempt' to make unearned and earned tax rate similarYahoo Finance VideoThe worst mistake you can make on a Zoom job interview: \u2018It\u2019s the first thing that occurs and it never goes well\u2019Yahoo FinanceAdvertise with us\u00a9 2021 Verizon Media. All rights reserved.Data DisclaimerHelpSuggestionsPrivacy DashboardPrivacy (Updated)About Our AdsTerms (Updated)Sitema",
     "change_from_open": null,
     "change_from_open_percent": null
   },
   "VIR": {
-    "price": 48.62,
-    "refresh_time": "2021-04-23 11:52:32",
-    "market_cap": 6070000000.0,
+    "price": 48.42,
+    "refresh_time": "2021-04-23 11:57:11",
+    "market_cap": 6045000000.0,
     "name": "VIR - Vir Biotechnology, Inc.",
-    "change_from_open": -1.22,
-    "change_from_open_percent": -0.0245
+    "change_from_open": -1.42,
+    "change_from_open_percent": -0.0285
   }
 }

--- a/data.json
+++ b/data.json
@@ -1,106 +1,106 @@
 {
   "HBRI": {
-    "price": 936.2319,
-    "open": 28457338376.3,
-    "change_from_open": -370381376.29999924,
-    "change_from_open_percent": -0.013015320385987409,
-    "market_cap": 28086957000.0,
+    "price": 785.6161333333333,
+    "open": 23567664460.6,
+    "change_from_open": 819539.4000015259,
+    "change_from_open_percent": 3.477389120893236e-05,
+    "market_cap": 23568484000.0,
     "name": "HBRI - Hepatitis B Research Index"
   },
   "ABUS": {
-    "price": 4.33,
-    "refresh_time": "2021-02-15 14:31:42",
-    "market_cap": 367657000.0,
+    "price": 3.2,
+    "refresh_time": "2021-04-23 11:52:27",
+    "market_cap": 306622000.0,
     "name": "ABUS - Arbutus Biopharma Corporation",
-    "change_from_open": -0.05,
-    "change_from_open_percent": -0.011399999999999999
+    "change_from_open": 0.01,
+    "change_from_open_percent": 0.0031
   },
   "ALT": {
-    "price": 22.22,
-    "refresh_time": "2021-02-15 14:31:42",
-    "market_cap": 825315000.0,
+    "price": 12.57,
+    "refresh_time": "2021-04-23 11:52:28",
+    "market_cap": 457773000.0,
     "name": "ALT - Altimmune, Inc.",
-    "change_from_open": 0.14,
-    "change_from_open_percent": 0.0063
+    "change_from_open": -0.11,
+    "change_from_open_percent": -0.0087
   },
   "ARWR": {
-    "price": 88.2,
-    "refresh_time": "2021-02-15 14:31:43",
-    "market_cap": 9154000000.0,
+    "price": 71.35,
+    "refresh_time": "2021-04-23 11:52:28",
+    "market_cap": 7201000000.0,
     "name": "ARWR - Arrowhead Pharmaceuticals, Inc.",
-    "change_from_open": -0.14,
-    "change_from_open_percent": -0.0016
+    "change_from_open": 0.36,
+    "change_from_open_percent": 0.0051
   },
   "ASMB": {
-    "price": 6.29,
-    "refresh_time": "2021-02-15 14:31:43",
-    "market_cap": 207710000.0,
+    "price": 4.31,
+    "refresh_time": "2021-04-23 11:52:29",
+    "market_cap": 172655000.0,
     "name": "ASMB - Assembly Biosciences, Inc.",
-    "change_from_open": -0.08,
-    "change_from_open_percent": -0.0126
+    "change_from_open": -0.06,
+    "change_from_open_percent": -0.0137
   },
   "BBI": {
-    "price": 1.61,
-    "refresh_time": "2021-02-15 14:31:43",
-    "market_cap": 86160000.0,
+    "price": 0.9218,
+    "refresh_time": "2021-04-23 11:52:29",
+    "market_cap": 61696000.0,
     "name": "BBI - Brickell Biotech, Inc.",
-    "change_from_open": -0.01,
-    "change_from_open_percent": -0.0062
+    "change_from_open": 0.0347,
+    "change_from_open_percent": 0.0391
   },
   "DRNA": {
-    "price": 26.01,
-    "refresh_time": "2021-02-15 14:31:44",
-    "market_cap": 1952000000.0,
+    "price": 28.81,
+    "refresh_time": "2021-04-23 11:52:30",
+    "market_cap": 2207000000.0,
     "name": "DRNA - Dicerna Pharmaceuticals, Inc.",
-    "change_from_open": -0.18,
-    "change_from_open_percent": -0.0069
+    "change_from_open": -0.05,
+    "change_from_open_percent": -0.0017000000000000001
   },
   "DVAX": {
-    "price": 9.74,
-    "refresh_time": "2021-02-15 14:31:44",
-    "market_cap": 1073000000.0,
+    "price": 9.55,
+    "refresh_time": "2021-04-23 11:52:30",
+    "market_cap": 1076000000.0,
     "name": "DVAX - Dynavax Technologies Corporation",
-    "change_from_open": 0.21,
-    "change_from_open_percent": 0.022000000000000002
+    "change_from_open": 0.01,
+    "change_from_open_percent": 0.0005
   },
   "ENTA": {
-    "price": 51.32,
-    "refresh_time": "2021-02-15 14:31:45",
-    "market_cap": 1034999999.9999999,
+    "price": 51.06,
+    "refresh_time": "2021-04-23 11:52:31",
+    "market_cap": 1030000000.0,
     "name": "ENTA - Enanta Pharmaceuticals, Inc.",
-    "change_from_open": -2.51,
-    "change_from_open_percent": -0.0466
+    "change_from_open": -1.33,
+    "change_from_open_percent": -0.0254
   },
   "HEPA": {
-    "price": 2.97,
-    "refresh_time": "2021-02-15 14:31:45",
-    "market_cap": 95115000.0,
+    "price": 1.705,
+    "refresh_time": "2021-04-23 11:52:31",
+    "market_cap": 130738000.0,
     "name": "HEPA - Hepion Pharmaceuticals, Inc.",
-    "change_from_open": 0.13,
-    "change_from_open_percent": 0.0458
+    "change_from_open": 0.025,
+    "change_from_open_percent": 0.0149
   },
   "NTLA": {
-    "price": 68.28,
-    "refresh_time": "2021-02-15 14:31:45",
-    "market_cap": 4411000000.0,
+    "price": 76.8,
+    "refresh_time": "2021-04-23 11:52:31",
+    "market_cap": 4855000000.0,
     "name": "NTLA - Intellia Therapeutics, Inc.",
-    "change_from_open": -0.64,
-    "change_from_open_percent": -0.009300000000000001
+    "change_from_open": 2.2,
+    "change_from_open_percent": 0.029500000000000002
   },
   "SBPH": {
     "price": null,
-    "refresh_time": "2021-02-15 14:31:46",
+    "refresh_time": "2021-04-23 11:52:32",
     "market_cap": null,
-    "name": "SBPH - Spring Bank Pharmaceuticals, Inc.",
+    "name": "Symbol Lookup from Yahoo FinanceHomeMailNewsFinanceSportsEntertainmentSearchMobileMore...Yahoo FinanceSearchSign inMailSign in to view your mailFinance HomeWatchlistsMy PortfolioScreenersYahoo Finance PlusMarketsNewsPersonal FinanceVideosIndustriesTechContact UsU.S. markets close in 4 hours 8 minutesS&P 5004,175.26+40.28(+0.97%)Dow 3033,980.23+164.33(+0.49%)Nasdaq14,007.35+188.94(+1.37%)Symbols similar to 'sbph'All (8)Stocks (8)Mutual Funds (0)ETFs (0)Indices (0)Futures (0)Currencies (0)SymbolNameLast PriceIndustry / CategoryTypeExchangeSPHSuburban Propane Partners, L.P.14.65UtilitiesStocksNYQSBHSally Beauty Holdings, Inc. (Na20.46Consumer CyclicalStocksNYQTBPHTheravance Biopharma, Inc.21.30HealthcareStocksNGMLBPHLongboard Pharmaceuticals, Inc.10.94HealthcareStocksNGMSCPHscPharmaceuticals Inc.6.83HealthcareStocksNMSSPPHSPENCER PHARMACEUTICAL INC0.00N/AStocksPNKKBPHKYTO TECHNOLOGY AND LIFE SCI IN1.90Financial ServicesStocksPNKSBPHSBPHN/AN/AStocksNCMAlready got your third stimulus check? A bonus amount may be on the wayMoneyWiseEconomist: Government will 'attempt' to make unearned and earned tax rate similarYahoo Finance VideoThe worst mistake you can make on a Zoom job interview: \u2018It\u2019s the first thing that occurs and it never goes well\u2019Yahoo FinanceAdvertise with us\u00a9 2021 Verizon Media. All rights reserved.Data DisclaimerHelpSuggestionsPrivacy DashboardPrivacy (Updated)About Our AdsTerms (Updated)Sitema",
     "change_from_open": null,
     "change_from_open_percent": null
   },
   "VIR": {
-    "price": 69.71,
-    "refresh_time": "2021-02-15 14:31:46",
-    "market_cap": 8880000000.0,
+    "price": 48.62,
+    "refresh_time": "2021-04-23 11:52:32",
+    "market_cap": 6070000000.0,
     "name": "VIR - Vir Biotechnology, Inc.",
-    "change_from_open": -2.26,
-    "change_from_open_percent": -0.031400000000000004
+    "change_from_open": -1.22,
+    "change_from_open_percent": -0.0245
   }
 }


### PR DESCRIPTION
Switched from parsing text using HTML tags to extracting text using [BeautifulSoup4](https://pypi.org/project/beautifulsoup4/) and [re](https://docs.python.org/3/library/re.html) regex package. Should be more robust as it targets actual text, like 'Market Cap' rather than trying to find react tags which may change as the page is modified.

To install with pip: `pip install beautifulsoup4`